### PR TITLE
Use compatible option for uniq

### DIFF
--- a/src/services/count-commits-per-file.ts
+++ b/src/services/count-commits-per-file.ts
@@ -66,7 +66,8 @@ function buildCommand(directory, { firstParent, since }): string {
       "'*.[tj]s'"
     ].join(" "),
     "sort",
-    "uniq --count"
+    // --count might not be supported by all OS
+    "uniq -c"
   ].join(" | ");
 }
 


### PR DESCRIPTION
`uniq --count` doesn't exist on my machine (macOS v10.15.3, Catalina)

![](https://user-images.githubusercontent.com/1094774/78257150-76e11d80-74c7-11ea-9883-1c5fe859106b.png)

So I can't run the command anymore:

![](https://user-images.githubusercontent.com/1094774/78257216-8d877480-74c7-11ea-9cb6-c28cf9d3960e.png)

`uniq -c` is less explicit, but it seems more compatible.

Ideally, we would use a lib that would do an abstraction of the OS, so this can run on any system (e.g. Windows).