### PR TITLE
Added "until" cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # code-complexity
 
-> Measure the churn/complexity score. Higher values mean hotspots where 
+> Measure the churn/complexity score. Higher values mean hotspots where
 > refactorings should happen.
 
 [![Build Status][travis-image]][travis-url]
@@ -10,13 +10,13 @@
 
 Quoting Michael Feathers (source [here][michael-feathers-source]):
 
-*Often when we refactor, we look at local areas of code. If we take a wider 
-view, using information from our version control systems, we can get a better 
+*Often when we refactor, we look at local areas of code. If we take a wider
+view, using information from our version control systems, we can get a better
 sense of the effects of our refactoring efforts.*
 
 
-Note: `code-complexity` currently measures complexity using lines of code count. 
-While imperfect, this measure gives a good enough idea of what's going on. 
+Note: `code-complexity` currently measures complexity using lines of code count.
+While imperfect, this measure gives a good enough idea of what's going on.
 
 ## Usage
 
@@ -28,21 +28,22 @@ $ npx code-complexity <path-to-git-directory or URL>
 
 ```text
     Usage: code-complexity <target> [options]
-    
+
     Measure the churn/complexity score. Higher values mean hotspots where refactorings should happen.
-    
+
     Options:
       -V, --version          output the version number
       --filter <strings>     list of globs (comma separated) to filter
       -f, --format [format]  format results using table or json
       -l, --limit [limit]    limit the number of files to output
-      -i, --since [since]    limit the age of the commit analyzed
+      -i, --since [since]    limit analysis to commits more recent in age than date
+      -u, --until [until]    limit analysis to commits older in age than date
       -s, --sort [sort]      sort results (allowed valued: score,
                              churn, complexity or file)
       -h, --help             display help for command
-    
+
     Examples:
-    
+
     $ code-complexity .
     $ code-complexity https://github.com/simonrenoult/code-complexity
     $ code-complexity foo --limit 3

--- a/src/io/cli.ts
+++ b/src/io/cli.ts
@@ -53,7 +53,14 @@ function getRawCli(
       "limit the number of files to output",
       parseInt
     )
-    .option("-i, --since [since]", "limit the age of the commit analyzed")
+    .option(
+      "-i, --since [since]",
+      "limit analysis to commits more recent in age than date"
+    )
+    .option(
+      "-u, --until [until]",
+      "limit analysis to commits older in age than date"
+    )
     .option(
       "-s, --sort [sort]",
       "sort results (allowed valued: score, churn, complexity or file)",
@@ -83,6 +90,7 @@ function buildOptions(cli: CommanderStatic): Options {
     filter: cli.filter || [],
     limit: cli.limit ? Number(cli.limit) : undefined,
     since: cli.since ? String(cli.since) : undefined,
+    until: cli.until ? String(cli.until) : undefined,
     sort: cli.sort ? (String(cli.sort) as Sort) : undefined,
   };
 

--- a/src/lib/churn.ts
+++ b/src/lib/churn.ts
@@ -89,6 +89,7 @@ function buildGitLogCommand(options: Options, isWindows: boolean): string {
     `--format=${isWindows ? "" : "''"}`,
     `--name-only`,
     options.since ? `--since="${options.since}"` : "",
+    options.until ? `--until="${options.until}"` : "",
 
     // Windows CMD handle quotes differently
     isWindows ? "*" : "'*'",

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -8,6 +8,7 @@ export type Options = {
   directory: string;
   limit?: number;
   since?: string;
+  until?: string;
   sort?: Sort;
   filter?: string[];
   format?: Format;


### PR DESCRIPTION
Since there are issues handling a large # of commits due to buffer overflow, I've added an until cli option to allow exporting an analysis for limited time windows.

Use case:

1. Analyzing over 5 months of commits causes a buffer overflow
2. Use since flag to limit to last 5 months, export results
3. Use since + until flag to set a new window to analyze (5-10 months ago)
4. Rinse, repeat.

This is more of a work-around to the buffer overflow issue.  Ideally, that issue should be addressed.  This works in the meantime and allows for analyzing different historical windows.