### PR TITLE
removing execAsync and add module support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ build/
 
 # IntelliJ stuff
 .idea/
+
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -39,10 +39,13 @@
   "license": "MIT",
   "dependencies": {
     "cli-table3": "^0.6.0",
+    "code-complexity": "^4.1.0",
     "commander": "^5.0.0",
     "debug": "^4.1.1",
+    "del": "^6.0.0",
     "micromatch": "^4.0.2",
-    "node-sloc": "^0.1.12"
+    "node-sloc": "^0.1.12",
+    "simple-git": "^3.7.1"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -1,7 +1,7 @@
+import Statistics from "../lib";
+import { Path } from "../lib/types";
 import Cli from "./cli";
 import Output from "./output";
-import { Path } from "../lib/types";
-import Statistics from "../lib";
 
 export default async function main(): Promise<void> {
   const options = await Cli.parse();

--- a/src/lib/churn.ts
+++ b/src/lib/churn.ts
@@ -1,10 +1,10 @@
-import { execSync } from "child_process";
 import { existsSync } from "fs";
 import * as micromatch from "micromatch";
 import { resolve } from "path";
 
-import { Options, Path } from "./types";
+import git from "simple-git";
 import { buildDebugger, withDuration } from "../utils";
+import { Options, Path } from "./types";
 
 type ParsedLine = { relativePath: string; commitCount: string };
 const internal = { debug: buildDebugger("churn") };
@@ -16,18 +16,24 @@ export default {
 };
 
 async function compute(options: Options): Promise<Map<Path, number>> {
-  assertGitIsInstalled();
-  assertIsGitRootDirectory(options.directory);
+  //assertGitIsInstalled();
+  //assertIsGitRootDirectory(options.directory);
 
   const isWindows = process.platform === "win32";
-  const gitLogCommand = buildGitLogCommand(options, isWindows);
+
+  const gitcli = await git(options.directory);
+  const gitLogCommand = await buildGitLogCommand(options, isWindows);
+  console.log(gitLogCommand);
+
+  const log = await gitcli.log(gitLogCommand.filter(r => r !== ''));
+  
 
   internal.debug(`command to measure churns: ${gitLogCommand}`);
 
-  const gitLogStdout = execSync(gitLogCommand, { encoding: "utf8" });
+  //const gitLogStdout = execSync(gitLogCommand, { encoding: "utf8" });
 
   const parsedLines: ParsedLine[] = computeNumberOfTimesFilesChanged(
-    gitLogStdout
+    log.latest?.hash || ""
   ).filter((parsedLine: ParsedLine) => {
     return existsSync(resolve(options.directory, parsedLine.relativePath));
   });
@@ -63,39 +69,34 @@ async function compute(options: Options): Promise<Map<Path, number>> {
   return filteredChurns;
 }
 
-function assertGitIsInstalled(): void {
+/*function assertGitIsInstalled(): void {
   try {
     execSync("which git");
   } catch (error) {
     throw new Error("Program 'git' must be installed");
   }
-}
+}*/
 
-function assertIsGitRootDirectory(directory: string): void {
+/*function assertIsGitRootDirectory(directory: string): void {
   if (!existsSync(`${directory}/.git`)) {
     throw new Error(`Argument 'dir' must be the git root directory.`);
   }
-}
+}*/
 
-function buildGitLogCommand(options: Options, isWindows: boolean): string {
+async function buildGitLogCommand(options: Options, isWindows: boolean): Promise<string[]> {
   return [
-    "git",
-    `-C ${options.directory}`,
-    `log`,
     `--follow`,
 
     // Windows CMD handle quotes differently than linux, this is why we should put empty string as said in:
     // https://github.com/git-for-windows/git/issues/3131
-    `--format=${isWindows ? "" : "''"}`,
+    `--pretty=format:${isWindows ? "" : "''"}`,
     `--name-only`,
     options.since ? `--since="${options.since}"` : "",
     options.until ? `--until="${options.until}"` : "",
 
     // Windows CMD handle quotes differently
     isWindows ? "*" : "'*'",
-  ]
-    .filter((s) => s.length > 0)
-    .join(" ");
+  ];
 }
 
 function computeNumberOfTimesFilesChanged(gitLogOutput: string): ParsedLine[] {

--- a/src/lib/execute.ts
+++ b/src/lib/execute.ts
@@ -1,0 +1,14 @@
+import Statistics from ".";
+import Cli from "../io/cli";
+import { Command, Path } from "./types";
+
+export default async function main(params: Command): Promise<any> {
+  const options = await Cli.parse(params);
+  const statistics: Map<Path, Statistics> = await Statistics.compute(options);
+
+  Cli.cleanup(options);
+
+  const values = JSON.parse(JSON.stringify(Array.from(statistics.values())));
+
+  return values;
+};

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,6 @@
+import execute from "./execute";
 import Statistics from "./statistics";
 
 export default Statistics;
+export { execute };
+

--- a/src/lib/statistics.ts
+++ b/src/lib/statistics.ts
@@ -1,7 +1,7 @@
+import { buildDebugger } from "../utils";
 import Churn from "./churn";
 import Complexity from "./complexity";
 import { Options, Path, Sort } from "./types";
-import { buildDebugger } from "../utils";
 
 const DEFAULT_CHURN = 1;
 const DEFAULT_COMPLEXITY = 1;
@@ -31,6 +31,7 @@ export default class Statistics {
     const paths = Array.from(churns.keys());
     const complexities = await Complexity.compute(paths, options);
 
+    
     const statistics = paths
       .map(toStatistics(churns, complexities))
       .sort(sort(options.sort))

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -1,10 +1,9 @@
-import { URL } from "url";
 
 export type Path = string;
 export type Sort = "score" | "churn" | "complexity" | "file" | "ratio";
 export type Format = "table" | "json" | "csv";
 export type Options = {
-  target: string | URL;
+  target: string;
   directory: string;
   limit?: number;
   since?: string;
@@ -12,4 +11,12 @@ export type Options = {
   sort?: Sort;
   filter?: string[];
   format?: Format;
+};
+export type Command = {
+  target: string;
+  limit?: number;
+  since?: string;
+  until?: string;
+  sort?: Sort;
+  filter?: string[];
 };

--- a/test/lib/module.test.ts
+++ b/test/lib/module.test.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+
+import { execute } from "../../src/lib";
+import { Command } from "../../src/lib/types";
+
+describe("Statistics", () => {
+  const params: Command = {
+    target: "https://github.com/l-marcel/exe-classwork",
+    filter: [],
+    limit: 3,
+    since: undefined,
+    sort: "score",
+  };
+
+  context("module", () => {
+    it("returns the appropriate number of elements", async () => {
+      // When
+      const result = await execute(params);
+      console.log(result);
+      // Then
+      expect(result.length).equals(3);
+    });
+  });
+});


### PR DESCRIPTION
Need more support, but, this code is able to run the code-compexity like a module.

```jsx
const execute = require("../../src/lib");
const result = await execute(params);
```

You need check cli support, but, it's working for me.

Note: check the simple-git library to remove all execAsync... (execAsync is... strange).