### PR TITLE
Proposal: Increase buffer size for execSync call

### DIFF
--- a/src/lib/churn.ts
+++ b/src/lib/churn.ts
@@ -24,7 +24,10 @@ async function compute(options: Options): Promise<Map<Path, number>> {
 
   internal.debug(`command to measure churns: ${gitLogCommand}`);
 
-  const gitLogStdout = execSync(gitLogCommand, { encoding: "utf8" });
+  const gitLogStdout = execSync(gitLogCommand, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
 
   const parsedLines: ParsedLine[] = computeNumberOfTimesFilesChanged(
     gitLogStdout


### PR DESCRIPTION
I'm using code-complexity against a large monorepo at work and am running into `ENOBUFS` errors, even when using `since` and `until` flags for < 4 weeks. 
Some statistics about the monorepo: 6 years old, 120k commits, ~500k SLOC in TS, ~30k files currently on master.

The `until` flag was added as a kind of workaround for this issue in #29.
I noticed the possibility to increase the buffer size via `execSync` options (defaults to 1MB; this PR proposes 32MB)

A buffer size of 32MB is enough to fit the complete history into one `code-complexity` command (neither `since` or `util` flags are necessary). `code-complexity` runs for ~13s on my M1 Mac.

Was there any specific reason for you to avoid increasing the buffer size and opting for `until` instead?
What do you think about increasing it? 


Thank you for your work on code-complexity – it's a _really_ nice tool! 💯 ❤️ 