### PR TITLE
Remove src imports from dist

### DIFF
--- a/src/io/output.ts
+++ b/src/io/output.ts
@@ -1,5 +1,5 @@
 import * as Table from "cli-table3";
-import { IStatistic } from "../../dist/src/lib/statistics";
+import { IStatistic } from "../lib/statistics/statistic";
 import { Options } from "../lib/types";
 
 import { buildDebugger, withDuration } from "../utils";

--- a/src/lib/statistics/statistic.ts
+++ b/src/lib/statistics/statistic.ts
@@ -2,7 +2,7 @@ import * as NodePath from "node:path";
 
 import { Path } from "../types";
 
-interface IStatistic {
+export interface IStatistic {
   path: string;
   churn: number;
   complexity: number;

--- a/src/lib/statistics/statistics.ts
+++ b/src/lib/statistics/statistics.ts
@@ -1,4 +1,4 @@
-import { IStatistic } from "../../../dist/src/lib/statistics";
+import { IStatistic } from "./statistic";
 import { buildDebugger } from "../../utils";
 import Churns from "../churn/churns";
 import Complexities from "../complexity/complexities";


### PR DESCRIPTION
Hey I don't know if it was intentional to import the IStatistic interface from the build but it was throwing some build errors for me.