### PR TITLE
pass filename to transfromSync

### DIFF
--- a/src/lib/complexity/strategies/cyclomatic.ts
+++ b/src/lib/complexity/strategies/cyclomatic.ts
@@ -27,6 +27,7 @@ export function calculate(path: string): number | UnsupportedExtension {
 function fromJavaScript(path: string): number {
   const content = readFileSync(path, { encoding: "utf8" });
   const babelResult = transformSync(content, {
+    filename: path,
     presets: ["@babel/preset-env"],
   });
   if (!babelResult) throw new Error(`Error while parsing file ${path}`);
@@ -37,6 +38,7 @@ function fromJavaScript(path: string): number {
 function fromTypeScript(path: string): number {
   const content = readFileSync(path, { encoding: "utf8" });
   const babelResult = transformSync(content, {
+    filename: path,
     plugins: ["@babel/plugin-transform-typescript"],
     presets: ["@babel/preset-env"],
   });

--- a/src/lib/complexity/strategies/halstead.ts
+++ b/src/lib/complexity/strategies/halstead.ts
@@ -26,6 +26,7 @@ export function calculate(path: string): number | UnsupportedExtension {
 function fromJavaScript(path: string): number {
   const content = readFileSync(path, { encoding: "utf8" });
   const babelResult = transformSync(content, {
+    filename: path,
     presets: ["@babel/preset-env"],
   });
   if (!babelResult) throw new Error(`Error while parsing file ${path}`);
@@ -36,6 +37,7 @@ function fromJavaScript(path: string): number {
 function fromTypeScript(path: string): number {
   const content = readFileSync(path, { encoding: "utf8" });
   const babelResult = transformSync(content, {
+    filename: path,
     plugins: ["@babel/plugin-transform-typescript"],
     presets: ["@babel/preset-env"],
   });


### PR DESCRIPTION
I didn't see any contributor documentation but wanted to open this PR in case it helps anyone else.

Thanks for creating this tool its exactly what I was looking for!

When I attempted to use it I was getting the following error.

```
ConfigError: [BABEL] unknown file: Preset /* your preset */ requires a filename to be set when babel is called directly,

babel.transformSync(code, { filename: 'file.ts', presets: [/* your preset */] });

See https://babeljs.io/docs/en/options#filename for more information.
    at transformSync (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/node_modules/@babel/core/lib/transform.js:42:76)
    at fromJavaScript (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/complexity/strategies/cyclomatic.js:26:50)
    at calculate (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/complexity/strategies/cyclomatic.js:17:20)
    at Complexity.computeComplexity (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/complexity/complexity.js:28:59)
    at Complexity.compute (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/complexity/complexity.js:13:45)
    at /Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/complexity/complexities.js:10:98
    at Array.map (<anonymous>)
    at Complexities.computeFor (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/complexity/complexities.js:10:54)
    at Statistics.compute (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/lib/statistics/statistics.js:16:59)
    at main (/Users/dan/.nvm/versions/node/v18.19.0/lib/node_modules/code-complexity/dist/src/io/index.js:13:44)
```

I didn't see any other bug reports so perhaps this is a misconfiguration within my project. Let me know if that might be the case

Version info from my project
```
Node: v18.19.0
"@babel/core": "^7.23.2",
"@babel/preset-env": "^7.23.2",
"@babel/preset-typescript": "^7.23.2",
"typescript": "^4.7.4",
```