### PR TITLE
Add maxBuffer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@
 
 Quoting Michael Feathers (source [here][michael-feathers-source]):
 
-_Often when we refactor, we look at local areas of code. If we take a wider
+*Often when we refactor, we look at local areas of code. If we take a wider
 view, using information from our version control systems, we can get a better
-sense of the effects of our refactoring efforts._
+sense of the effects of our refactoring efforts.*
 
 Note: `code-complexity` currently measures complexity using either:
-
 - lines of code count (all languages)
 - cyclomatic complexity (JavaScript/TypeScript)
 - halstead complexity (JavaScript/TypeScript)
@@ -84,8 +83,8 @@ A special thanks to a few contributors that helped me make `code-complexity` bet
 - Alexander Dormann (alexdo) for fixing the `ENOBUFS` (and apologies for stealing your code).
 - Scott Brooks (scottamplitude) for initiating the work on complexity strategies
 
-[michael-feathers-source]: https://www.stickyminds.com/article/getting-empirical-about-refactoring
-[travis-image]: https://img.shields.io/travis/simonrenoult/code-complexity/master.svg?style=flat-square
+[michael-feathers-source]:https://www.stickyminds.com/article/getting-empirical-about-refactoring
+[travis-image]:https://img.shields.io/travis/simonrenoult/code-complexity/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/simonrenoult/code-complexity
 [style-image]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square
 [style-url]: https://prettier.io/

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 
 Quoting Michael Feathers (source [here][michael-feathers-source]):
 
-*Often when we refactor, we look at local areas of code. If we take a wider
+_Often when we refactor, we look at local areas of code. If we take a wider
 view, using information from our version control systems, we can get a better
-sense of the effects of our refactoring efforts.*
-
+sense of the effects of our refactoring efforts._
 
 Note: `code-complexity` currently measures complexity using either:
+
 - lines of code count (all languages)
 - cyclomatic complexity (JavaScript/TypeScript)
 - halstead complexity (JavaScript/TypeScript)
@@ -43,6 +43,7 @@ $ npx code-complexity <path-to-git-directory or URL> [options]
       -u, --until [until]                   limit analysis to commits older in age than date
       -s, --sort [sort]                     sort results (allowed valued: score, churn, complexity or file)
       -d, --directories                     display values for directories instead of files
+      -mb, --max-buffer [maxBuffer]         set the max buffer size for git log (in bytes)
       -h, --help                            display help for command
 
     Examples:
@@ -53,10 +54,11 @@ $ npx code-complexity <path-to-git-directory or URL> [options]
     $ code-complexity ../foo --sort score
     $ code-complexity /foo/bar --filter 'src/**,!src/front/**'
     $ code-complexity . --limit 10 --sort score
-    $ code-complexity . --limit 10 --directories 
+    $ code-complexity . --limit 10 --directories
     $ code-complexity . --limit 10 --sort score -cs halstead
     $ code-complexity . --since=2021-06-01 --limit 100
     $ code-complexity . --since=2021-04-01 --until=2021-07-01
+    $ code-complexity . --max-buffer 64000000
 ```
 
 ## Output
@@ -82,8 +84,8 @@ A special thanks to a few contributors that helped me make `code-complexity` bet
 - Alexander Dormann (alexdo) for fixing the `ENOBUFS` (and apologies for stealing your code).
 - Scott Brooks (scottamplitude) for initiating the work on complexity strategies
 
-[michael-feathers-source]:https://www.stickyminds.com/article/getting-empirical-about-refactoring
-[travis-image]:https://img.shields.io/travis/simonrenoult/code-complexity/master.svg?style=flat-square
+[michael-feathers-source]: https://www.stickyminds.com/article/getting-empirical-about-refactoring
+[travis-image]: https://img.shields.io/travis/simonrenoult/code-complexity/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/simonrenoult/code-complexity
 [style-image]: https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square
 [style-url]: https://prettier.io/

--- a/src/io/cli.ts
+++ b/src/io/cli.ts
@@ -79,6 +79,11 @@ function getRawCli(
       "-d, --directories",
       "display values for directories instead of files"
     )
+    .option(
+      "-mb, --max-buffer [maxBuffer]",
+      "set the max buffer size for git log (in bytes)",
+      parseInt
+    )
     .on("--help", () => {
       console.log();
       console.log("Examples:");
@@ -94,6 +99,7 @@ function getRawCli(
         "$ code-complexity . --limit 10 --sort score -cs halstead",
         "$ code-complexity . --since=2021-06-01 --limit 100",
         "$ code-complexity . --since=2021-04-01 --until=2021-07-01",
+        "$ code-complexity . --max-buffer 64000000",
       ].forEach((example) => console.log(example.padStart(2)));
     });
 }
@@ -113,6 +119,7 @@ function buildOptions(args: string[], options: any): Options {
     complexityStrategy: options.complexityStrategy
       ? (String(options.complexityStrategy) as ComplexityStrategy)
       : "sloc",
+    maxBuffer: options.maxBuffer ? Number(options.maxBuffer) : undefined,
   };
 
   // FIXME: I'm not a fan of pulling the code here but it's good enough.

--- a/src/lib/githistory/githistory.ts
+++ b/src/lib/githistory/githistory.ts
@@ -68,7 +68,8 @@ export default class GitHistory {
   }
 
   private executeGitLogCommand(gitLogCommand: string): string {
-    return execSync(gitLogCommand, { encoding: "utf8", maxBuffer: 32_000_000 });
+    const maxBuffer = this.options.maxBuffer ?? 32_000_000;
+    return execSync(gitLogCommand, { encoding: "utf8", maxBuffer });
   }
 
   private listFiles(): string[] {

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -15,4 +15,5 @@ export type Options = {
   complexityStrategy?: ComplexityStrategy;
   filter?: string[];
   format?: Format;
+  maxBuffer?: number;
 };

--- a/test/lib/statistics.test.ts
+++ b/test/lib/statistics.test.ts
@@ -442,6 +442,27 @@ describe("Statistics", () => {
     });
   });
 
+  context("options.maxBuffer", () => {
+    it("returns the appropriate elements", async () => {
+      // Given
+      const options: Options = { ...defaultOptions, maxBuffer: 64_000_000 };
+      new TestRepositoryFixture().addFile({ name: "a.js" }).writeOnDisk();
+
+      // When
+      const result = (await Statistics.compute(options)).list();
+
+      // Then
+      expect(result).to.deep.equal([
+        {
+          churn: 1,
+          complexity: 1,
+          path: "a.js",
+          score: 1,
+        },
+      ]);
+    });
+  });
+
   context("when file no longer exists", () => {
     it("it is ignored", async () => {
       // Given


### PR DESCRIPTION
Closes https://github.com/simonrenoult/code-complexity/issues/59

This PR fix the issue above by adding `maxBuffer` option for `git log` execution. This option allow us to allocate `maxBuffer` if needed, especially when we expect a large output of `git log`