### PR TITLE
fix: add support for decorators to babel

### DIFF
--- a/src/lib/complexity/strategies/cyclomatic/index.ts
+++ b/src/lib/complexity/strategies/cyclomatic/index.ts
@@ -12,7 +12,7 @@ export function calculate(path: string): number | UnsupportedExtension {
     case ".ts":
       return computeFromBabel(path, {
         sourceType: "unambiguous",
-        plugins: ["typescript"],
+        plugins: ["typescript", "decorators"],
       });
     case ".mjs":
     case ".cjs":

--- a/src/lib/complexity/strategies/halstead/index.ts
+++ b/src/lib/complexity/strategies/halstead/index.ts
@@ -10,7 +10,7 @@ export function calculate(path: string): number | UnsupportedExtension {
     case ".ts":
       return computeFromBabel(path, {
         sourceType: "unambiguous",
-        plugins: ["typescript"],
+        plugins: ["typescript", "decorators"],
       });
     case ".mjs":
     case ".cjs":


### PR DESCRIPTION
NestJS uses decorators extensively. Decorators support is baked into babel, so there's no need for an additional plugin. This PR supercedes https://github.com/simonrenoult/code-complexity/pull/54 for the alpha version.